### PR TITLE
Ex3 js objects part 1

### DIFF
--- a/src/ex3_js-objects-part1/task-01.js
+++ b/src/ex3_js-objects-part1/task-01.js
@@ -1,0 +1,11 @@
+function createObject() {
+  const obj = {
+    string: 'string',
+    number: 123,
+    boolean: true
+  };
+  delete obj.boolean;
+  return obj;
+}
+
+module.exports = createObject;

--- a/src/ex3_js-objects-part1/task-02.js
+++ b/src/ex3_js-objects-part1/task-02.js
@@ -1,0 +1,7 @@
+function showObject(obj) {
+  for (let key in obj) {
+    if (obj.hasOwnProperty(key)) console.log(key, obj.key);
+  }
+}
+
+module.exports = showObject;

--- a/src/ex3_js-objects-part1/task-03.js
+++ b/src/ex3_js-objects-part1/task-03.js
@@ -1,0 +1,6 @@
+function hasObjProp(prop, obj) {
+  for (let key in obj) if (key === prop) return true;
+  return false;
+}
+
+module.exports = hasObjProp;

--- a/src/ex3_js-objects-part1/task-04.js
+++ b/src/ex3_js-objects-part1/task-04.js
@@ -1,0 +1,7 @@
+function addObjProp(prop, obj) {
+  // eslint-disable-next-line no-param-reassign
+  if (!obj.hasOwnProperty(prop)) obj[prop] = 'new'; // можно использовать функцию проверки на наличие свойства из task-03
+  return obj;
+}
+
+module.exports = addObjProp;

--- a/src/ex3_js-objects-part1/task-05.js
+++ b/src/ex3_js-objects-part1/task-05.js
@@ -1,0 +1,9 @@
+function createCopyObject(obj) {
+  const newObj = {};
+  for (let key in obj) {
+    if (obj.hasOwnProperty(key)) newObj[key] = obj[key]; // ESLint не пропускает без hasOwnProperty
+  }
+  return newObj;
+}
+
+module.exports = createCopyObject;

--- a/src/ex3_js-objects-part1/task-06.js
+++ b/src/ex3_js-objects-part1/task-06.js
@@ -1,0 +1,13 @@
+function deepCopyObj(obj) {
+  const newObj = {};
+  for (let key in obj) {
+    if (!obj.hasOwnProperty(key)) continue;
+
+    if (Array.isArray(obj[key])) newObj[key] = obj[key].slice();
+    else if (typeof obj[key] === 'object') newObj[key] = deepCopyObj(obj[key]);
+    else newObj[key] = obj[key];
+  }
+  return newObj;
+}
+
+module.exports = deepCopyObj;


### PR DESCRIPTION
hasOwnProperty() добавлены в циклы for-in по требованию ESLint.

"eslint-disable-next-line no-param-reassign" в task-04.js, потому что ESLint не разрешает модификацию входного объекта. Если создать внутри функции новый объект с решением и его вернуть, тесты валятся. (проверка в тесте происходит по адресу входного объекта?)